### PR TITLE
Fix Warnings and Errors for Metal API

### DIFF
--- a/Editor/HairAssetEditor.cs
+++ b/Editor/HairAssetEditor.cs
@@ -516,6 +516,9 @@ namespace Unity.DemoTeam.Hair
 
 										previewMaterial.CopyPropertiesFromMaterial(sourceMaterial);
 									}
+									
+									// Enable the variant that will read from the simulation buffers.
+									previewMaterial.EnableKeyword("HAIR_VERTEX_LIVE");
 
 									HairSim.BindSolverData(previewMaterial, previewData[i]);
 

--- a/Editor/HairShaderVariantStripper.cs
+++ b/Editor/HairShaderVariantStripper.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Rendering;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Unity.DemoTeam.Hair
+{
+    public class HairShaderVariantStripper : IPreprocessShaders
+    {
+        public int callbackOrder { get; }
+        
+        ShaderKeyword m_HairVertexStaticVariant;
+
+        public HairShaderVariantStripper()
+        {
+            // NOTE: Must be kept in sync with the variant defined in HairVertex sub-graph.
+            m_HairVertexStaticVariant = new ShaderKeyword("HAIR_VERTEX_STATIC");
+        }
+        
+        public void OnProcessShader(Shader shader, ShaderSnippetData snippet, IList<ShaderCompilerData> data)
+        {
+            for (int i = 0; i < data.Count; ++i)
+            {
+                if (data[i].shaderKeywordSet.IsEnabled(m_HairVertexStaticVariant))
+                {
+                    data.RemoveAt(i);
+                    --i;
+                }
+            }
+        }
+    }
+}

--- a/Editor/HairShaderVariantStripper.cs.meta
+++ b/Editor/HairShaderVariantStripper.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4e937113e8684df3900b523cbb613360
+timeCreated: 1698266256

--- a/Runtime/HairInstance.cs
+++ b/Runtime/HairInstance.cs
@@ -1335,6 +1335,11 @@ namespace Unity.DemoTeam.Hair
 		{
 			HairSim.BindSolverData(materialInstance, solverData);
 			HairSim.BindVolumeData(materialInstance, volumeData);
+			
+		#if UNITY_EDITOR
+			// Enable the editor-only variant compiled with the simulation buffers. 
+			materialInstance.EnableKeyword("HAIR_VERTEX_LIVE");
+		#endif
 
 			materialInstance.SetTexture("_UntypedVolumeDensity", volumeData.volumeDensity);
 			materialInstance.SetTexture("_UntypedVolumeVelocity", volumeData.volumeVelocity);

--- a/Runtime/HairMaterialDefaultLitBuiltin.shader
+++ b/Runtime/HairMaterialDefaultLitBuiltin.shader
@@ -4,6 +4,8 @@ Shader "Hair/Default/HairMaterialDefaultLitBuiltin"
 
 	#pragma target 5.0
 
+	#pragma multi_compile HAIR_VERTEX_STATIC HAIR_VERTEX_LIVE
+
 	#include "HairMaterialCommonBuiltin.hlsl"
 
 	ENDCG

--- a/Runtime/HairMaterialDefaultUnlit.shader
+++ b/Runtime/HairMaterialDefaultUnlit.shader
@@ -3,6 +3,8 @@ Shader "Hair/Default/HairMaterialDefaultUnlit"
 	HLSLINCLUDE
 
 	#pragma target 5.0
+	
+	#pragma multi_compile HAIR_VERTEX_STATIC HAIR_VERTEX_LIVE
 
 	#include "HairMaterialCommonUnlit.hlsl"
 

--- a/Runtime/HairMaterialReplaceAsync.shader
+++ b/Runtime/HairMaterialReplaceAsync.shader
@@ -4,6 +4,8 @@ Shader "Hair/Hidden/HairMaterialReplaceAsync"
 
 	#pragma target 5.0
 	#pragma editor_sync_compilation
+	
+	#pragma multi_compile HAIR_VERTEX_STATIC HAIR_VERTEX_LIVE
 
 	#include "HairMaterialCommonUnlit.hlsl"
 

--- a/Runtime/HairMaterialReplaceError.shader
+++ b/Runtime/HairMaterialReplaceError.shader
@@ -4,6 +4,8 @@ Shader "Hair/Hidden/HairMaterialReplaceError"
 
 	#pragma target 5.0
 	#pragma editor_sync_compilation
+	
+	#pragma multi_compile HAIR_VERTEX_STATIC HAIR_VERTEX_LIVE
 
 	#include "HairMaterialCommonUnlit.hlsl"
 

--- a/Runtime/HairSim.cs
+++ b/Runtime/HairSim.cs
@@ -29,6 +29,21 @@ namespace Unity.DemoTeam.Hair
 		static MaterialPropertyBlock s_debugDrawPB;
 
 		static RuntimeFlags s_runtimeFlags;
+		
+		static ComputeBuffer s_DummyComputeBuffer;
+		
+		public static ComputeBuffer dummyComputeBuffer
+		{
+			get
+			{
+				if (s_DummyComputeBuffer == null || !s_DummyComputeBuffer.IsValid())
+				{
+					s_DummyComputeBuffer = new ComputeBuffer(1, sizeof(uint), ComputeBufferType.Raw);
+				}
+
+				return s_DummyComputeBuffer;
+			}
+		}
 
 		[Flags]
 		enum RuntimeFlags
@@ -912,8 +927,8 @@ namespace Unity.DemoTeam.Hair
 			target.BindComputeBuffer(UniformIDs._LODGuideIndex, solverData.lodGuideIndex);
 			target.BindComputeBuffer(UniformIDs._LODGuideCarry, solverData.lodGuideCarry);
 
-			target.BindComputeBuffer(UniformIDs._StagingPosition, solverData.stagingPosition);
-			target.BindComputeBuffer(UniformIDs._StagingPositionPrev, solverData.stagingPositionPrev);
+			target.BindComputeBuffer(UniformIDs._StagingPosition, solverData.stagingPosition ?? dummyComputeBuffer);
+			target.BindComputeBuffer(UniformIDs._StagingPositionPrev, solverData.stagingPositionPrev ?? dummyComputeBuffer);
 
 			target.BindKeyword("LAYOUT_INTERLEAVED", solverData.keywords.LAYOUT_INTERLEAVED);
 			target.BindKeyword("LIVE_POSITIONS_3", solverData.keywords.LIVE_POSITIONS_3);

--- a/Runtime/HairSimComputeSolverQuaternion.hlsl
+++ b/Runtime/HairSimComputeSolverQuaternion.hlsl
@@ -191,12 +191,16 @@ float4 QDecomposeTwist(float4 q, float3 axis)
 	float4 r = float4(p.x, p.y, p.z, q.w);
 
 	if (dot(r, r) < 1e-5)
-		return MakeQuaternionIdentity();
-
-	if (dn < 0.0)
-		return normalize(-r);
+		r = MakeQuaternionIdentity();
 	else
-		return normalize(r);
+	{
+		if (dn < 0.0)
+			r = normalize(-r);
+		else
+			r = normalize(r);
+	}
+
+	return r;
 }
 
 #endif//__HAIRSIMCOMPUTEQUATERNION_HLSL__

--- a/Runtime/HairVertex.hlsl
+++ b/Runtime/HairVertex.hlsl
@@ -272,10 +272,11 @@ HairVertex GetHairVertex(
 	in float3 in_staticNormalOS,
 	in float3 in_staticTangentOS)
 {
-	if (_DecodeVertexCount > 0)
+#if HAIR_VERTEX_LIVE
 		return GetHairVertex_Live(in_packedID, in_packedUV);
-	else
+#else
 		return GetHairVertex_Static(in_staticPositionOS, in_staticNormalOS, in_staticTangentOS);
+#endif
 }
 
 void HairVertex_float(

--- a/Runtime/HairVertex.shadersubgraph
+++ b/Runtime/HairVertex.shadersubgraph
@@ -1,9 +1,19 @@
 {
-    "m_SGVersion": 2,
+    "m_SGVersion": 3,
     "m_Type": "UnityEditor.ShaderGraph.GraphData",
     "m_ObjectId": "d1afb942372c49b6be7e6f382d135a78",
     "m_Properties": [],
-    "m_Keywords": [],
+    "m_Keywords": [
+        {
+            "m_Id": "6cb299f2ad4546df9dceccc4aa8b0f69"
+        }
+    ],
+    "m_Dropdowns": [],
+    "m_CategoryData": [
+        {
+            "m_Id": "8b6845941163439e8eae72d9873bd033"
+        }
+    ],
     "m_Nodes": [
         {
             "m_Id": "05907e129e0b4526858a9d2d669f647a"
@@ -266,10 +276,12 @@
         "serializedMesh": {
             "m_SerializedMesh": "{\"mesh\":{\"instanceID\":0}}",
             "m_Guid": ""
-        }
+        },
+        "preventRotation": false
     },
     "m_Path": "Hair",
-    "m_ConcretePrecision": 0,
+    "m_GraphPrecision": 0,
+    "m_PreviewMode": 2,
     "m_OutputNode": {
         "m_Id": "05907e129e0b4526858a9d2d669f647a"
     },
@@ -350,6 +362,8 @@
     "synonyms": [],
     "m_Precision": 0,
     "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
     },
@@ -518,21 +532,21 @@
 }
 
 {
-    "m_SGVersion": 0,
+    "m_SGVersion": 1,
     "m_Type": "UnityEditor.ShaderGraph.CustomFunctionNode",
     "m_ObjectId": "1f91cf420025464eaead59f9d50b1e80",
     "m_Group": {
         "m_Id": ""
     },
-    "m_Name": "Custom Function",
+    "m_Name": "HairVertex (Custom Function)",
     "m_DrawState": {
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": -75.00003814697266,
-            "y": -182.00001525878907,
-            "width": 244.0,
-            "height": 262.0
+            "x": -78.00003814697266,
+            "y": -182.5,
+            "width": 269.0000305175781,
+            "height": 494.0000305175781
         }
     },
     "m_Slots": [
@@ -584,7 +598,9 @@
     ],
     "synonyms": [],
     "m_Precision": 0,
-    "m_PreviewExpanded": false,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
     },
@@ -733,6 +749,42 @@
 }
 
 {
+    "m_SGVersion": 1,
+    "m_Type": "UnityEditor.ShaderGraph.ShaderKeyword",
+    "m_ObjectId": "6cb299f2ad4546df9dceccc4aa8b0f69",
+    "m_Guid": {
+        "m_GuidSerialized": "33f241b1-3718-4374-804c-604b92518759"
+    },
+    "m_Name": "HAIR_VERTEX",
+    "m_DefaultRefNameVersion": 1,
+    "m_RefNameGeneratedByDisplayName": "HAIR_VERTEX",
+    "m_DefaultReferenceName": "_HAIR_VERTEX",
+    "m_OverrideReferenceName": "HAIR_VERTEX",
+    "m_GeneratePropertyBlock": true,
+    "m_UseCustomSlotLabel": false,
+    "m_CustomSlotLabel": "",
+    "m_DismissedVersion": 0,
+    "m_KeywordType": 1,
+    "m_KeywordDefinition": 1,
+    "m_KeywordScope": 1,
+    "m_KeywordStages": 63,
+    "m_Entries": [
+        {
+            "id": 2,
+            "displayName": "STATIC",
+            "referenceName": "STATIC"
+        },
+        {
+            "id": 3,
+            "displayName": "LIVE",
+            "referenceName": "LIVE"
+        }
+    ],
+    "m_Value": 0,
+    "m_IsEditable": true
+}
+
+{
     "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.Vector3MaterialSlot",
     "m_ObjectId": "6d15fe48cebe45f690ab036cb09ae41f",
@@ -819,10 +871,13 @@
     "synonyms": [],
     "m_Precision": 1,
     "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 2,
     "m_CustomColors": {
         "m_SerializableColors": []
     },
-    "m_Space": 0
+    "m_Space": 0,
+    "m_PositionSource": 0
 }
 
 {
@@ -889,6 +944,18 @@
         "z": 0.0
     },
     "m_Labels": []
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.CategoryData",
+    "m_ObjectId": "8b6845941163439e8eae72d9873bd033",
+    "m_Name": "",
+    "m_ChildObjectList": [
+        {
+            "m_Id": "6cb299f2ad4546df9dceccc4aa8b0f69"
+        }
+    ]
 }
 
 {
@@ -1005,6 +1072,8 @@
     "synonyms": [],
     "m_Precision": 0,
     "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
     },
@@ -1037,6 +1106,8 @@
     "synonyms": [],
     "m_Precision": 0,
     "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
     "m_CustomColors": {
         "m_SerializableColors": []
     },
@@ -1084,6 +1155,8 @@
     "synonyms": [],
     "m_Precision": 0,
     "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 2,
     "m_CustomColors": {
         "m_SerializableColors": []
     },
@@ -1231,6 +1304,8 @@
     "synonyms": [],
     "m_Precision": 0,
     "m_PreviewExpanded": false,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 2,
     "m_CustomColors": {
         "m_SerializableColors": []
     },


### PR DESCRIPTION
Small PR that fixes some warnings and errors on Metal:

- Add editor-only variant for material previews that use HairVertex node.
- Bind a dummy buffer if StagingPosition is null.
- Fix a small uninitialized variable warning. 